### PR TITLE
Add code history tracking and loading service

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, ci/cd ]
     paths:
         - backend/**
+  pull_request:
+    branches: [ main ]
+    paths:
+        - backend/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, ci/cd ]
     paths:
         - frontend/**
+  pull_request:
+    branches: [ main ]
+    paths:
+        - frontend/**
 
 jobs:
   build:

--- a/backend/src/controller/getMyProgramCode.ts
+++ b/backend/src/controller/getMyProgramCode.ts
@@ -1,0 +1,28 @@
+import { GetData2 } from '../database/DataBaseRef'
+import { Get } from '../HttpResponse'
+import { GetMyProgramCodeParams, GetMyProgramCodeResults } from '../protocol/GetMyProgramCode'
+import { PracticeCode } from '../protocol/PostPracticeAnswer'
+
+export const getMyProgramCodeController = Get<GetMyProgramCodeParams, GetMyProgramCodeResults>(async (params, send) => {
+  try {
+    const snapshots = await GetData2<PracticeCode>(
+      `/result/${params.category}/${params.problemId}/${params.participantId}`
+    )
+
+    let unordered = JSON.parse(JSON.stringify(snapshots))
+
+    let idx = -1
+    for (const snapshot in snapshots) {
+      if (idx < Number(snapshot)) idx = Number(snapshot)
+    }
+
+    const code = unordered[String(idx)].code
+
+    send(200, { code })
+  } catch (error) {
+    send(500, {
+      message: '문제를 불러오는 데에 실패하였습니다. 페이지를 다시 로드해보세요.',
+      error,
+    })
+  }
+})

--- a/backend/src/controller/postPracticeAnswer.ts
+++ b/backend/src/controller/postPracticeAnswer.ts
@@ -1,14 +1,20 @@
 import { PythonSolutionTemplate, JavascriptSolutionTemplate } from '../constants/codeTemplates'
+import { SetData2 } from '../database/DataBaseRef'
 import { Post } from '../HttpResponse'
-import { PostPracticeAnswerParams, PostPracticeAnswerResults } from '../protocol/PostPracticeAnswer'
+import { PostPracticeAnswerParams, PostPracticeAnswerResults, PracticeCode } from '../protocol/PostPracticeAnswer'
 import { shellRunService } from '../service/shellRun'
 import { storageService } from '../service/storage'
 
 type Result = [boolean, string, string, string]
 
 export const postPracticeAnswerController = Post<PostPracticeAnswerParams, PostPracticeAnswerResults>(
-  async ({ code, problemId, codeType, category }, send) => {
+  async ({ code, problemId, codeType, category, participantId }, send) => {
     try {
+      await SetData2<PracticeCode>(
+        `/result/${category}/${problemId}/${participantId}/${Date.now()}`,
+        { code }
+      )
+
       const answerCode = await storageService.getFile(`${category}/${problemId}/solution.py`)
       if (!answerCode) {
         throw new Error('비교할 정답 파일을 불러올 수 없습니다.')

--- a/backend/src/protocol/GetMyProgramCode.ts
+++ b/backend/src/protocol/GetMyProgramCode.ts
@@ -1,0 +1,9 @@
+export interface GetMyProgramCodeParams {
+  category: string
+  problemId: string
+  participantId: string
+}
+
+export interface GetMyProgramCodeResults {
+  code: string
+}

--- a/backend/src/protocol/PostPracticeAnswer.ts
+++ b/backend/src/protocol/PostPracticeAnswer.ts
@@ -2,10 +2,15 @@ export interface PostPracticeAnswerParams {
   code: string
   codeType: 'python' | 'javascript'
   category: string
-  problemId: string
+  problemId: string,
+  participantId: string
 }
 
 export interface PostPracticeAnswerResults {
   output: string
   correct: boolean
+}
+
+export interface PracticeCode {
+  code: string
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import { getDocumentationController } from './controller/getDocumentation'
 import { getHealthController } from './controller/getHealth'
 import { getIdAndGroupController } from './controller/getIdAndGroup'
 import { GetLabelsController } from './controller/getLabels'
+import { getMyProgramCodeController } from './controller/getMyProgramCode'
 import { getNewSubgoalTreeController } from './controller/getNewSubgoalTree'
 import { getParsonsListController } from './controller/getParsonsList'
 import { getParticipationAvailabilityController } from './controller/getParticipationAvailability'
@@ -39,6 +40,7 @@ app.use(cors)
 
 app.get('/getHealth', getHealthController)
 app.get('/getIdAndGroup', getIdAndGroupController)
+app.get('/getMyProgramCode', getMyProgramCodeController)
 app.get('/getProgramCode', getProgramCodeController)
 app.get('/getProblem', getProblemController)
 app.get('/getProblemMarkDown', getProblemMarkDownController)

--- a/frontend/src/hooks/useMyCode.ts
+++ b/frontend/src/hooks/useMyCode.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+import { SERVER_ADDRESS } from '../environments/Configuration'
+import { GetMyProgramCodeParams, GetMyProgramCodeResults } from '../protocol/GetMyProgramCode'
+import { Get } from '../shared/HttpRequest'
+
+export function useMyCode(category: string, problemId: string, participantId: string) {
+  const [code, setCode] = useState('')
+
+  useEffect(() => {
+    Get<GetMyProgramCodeParams, GetMyProgramCodeResults>(
+      `${SERVER_ADDRESS}/getMyProgramCode`,
+      {
+        category,
+        problemId,
+        participantId,
+      },
+      result => {
+        setCode(result.code)
+      },
+      error => window.alert(error.message)
+    )
+  }, [problemId, category, participantId])
+
+  return code
+}

--- a/frontend/src/pages/Practice.tsx
+++ b/frontend/src/pages/Practice.tsx
@@ -71,6 +71,7 @@ function Practice(props: RouteComponentProps<MatchParams>) {
         category,
         problemId,
         codeType: mode,
+        participantId: getId() ?? ID_NOT_FOUND,
       },
       result => {
         setIsRunning(false)

--- a/frontend/src/pages/Vote.tsx
+++ b/frontend/src/pages/Vote.tsx
@@ -7,14 +7,14 @@ import MultipleChoice from '../components/MultipleChoice'
 import ProblemContainer from '../components/ProblemContainer'
 import StageNavigator from '../components/StageNavigator/StageNavigator'
 import TaskContainer from '../components/TaskContainer/TaskContainer'
-import { useCode } from '../hooks/useCode'
 import { useExplanation } from '../hooks/useExplanation'
 import { useHierarchyVisualier as useHierarchyVisualizer } from '../hooks/useHierarchyVisualizer'
+import { useMyCode } from '../hooks/useMyCode'
 import { useProblem } from '../hooks/useProblem'
 import { useVote } from '../hooks/useVote'
 import { useVoteSubmit } from '../hooks/useVoteSubmit'
 import { useVotingList } from '../hooks/useVotingList'
-import { nextStage } from '../shared/ExperimentHelper'
+import { getId, ID_NOT_FOUND, nextStage } from '../shared/ExperimentHelper'
 import { getString } from '../shared/Localization'
 import { getExampleNumber } from '../shared/Utils'
 import { InstructionTask } from '../templates/InstructionTask'
@@ -33,7 +33,7 @@ export interface ChoiceState {
 
 export default function Vote(props: RouteComponentProps<MatchParams>) {
   const { lecture, fileName } = props.match.params
-  const code = useCode(lecture, fileName)
+  const code = useMyCode(lecture, fileName, getId() ?? ID_NOT_FOUND)
   const problem = useProblem(lecture, fileName)
   const { votingList } = useVotingList(lecture, fileName)
   const { explanations } = useExplanation(lecture, fileName)


### PR DESCRIPTION
- Save users' code when they run their code
  - `/result/${category}/${problemId}/${participantId}/${Date.now()}`
- Load users' latest code when they open the labeling page
- Need to load proper votingItems